### PR TITLE
fix: replace deprecated `set-output` with `GITHUB_OUTPUT`

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -12,4 +12,5 @@ LABEL "com.github.actions.color"="blue"
 RUN npm install -g netlify-cli
 
 COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["sh", "/entrypoint.sh"]

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,5 +1,12 @@
 FROM node:22-alpine
 
+# Add required tools: perl for stripping ANSI escape sequences
+RUN apk add --no-cache perl
+
+# Install Netlify CLI
+RUN npm install -g netlify-cli
+
+# Action metadata (optional)
 LABEL version="2.0.0"
 LABEL repository="http://github.com/netlify/actions"
 LABEL homepage="http://github.com/netlify/actions/netlify"
@@ -8,8 +15,6 @@ LABEL "com.github.actions.name"="Netlify"
 LABEL "com.github.actions.description"="Wraps the Netlify CLI to enable common Netlify commands"
 LABEL "com.github.actions.icon"="cloud"
 LABEL "com.github.actions.color"="blue"
-
-RUN npm install -g netlify-cli
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,9 +1,5 @@
 FROM node:22-alpine
 
-# Install Netlify CLI
-RUN npm install -g netlify-cli
-
-# Action metadata (optional)
 LABEL version="2.0.0"
 LABEL repository="http://github.com/netlify/actions"
 LABEL homepage="http://github.com/netlify/actions/netlify"
@@ -13,9 +9,7 @@ LABEL "com.github.actions.description"="Wraps the Netlify CLI to enable common N
 LABEL "com.github.actions.icon"="cloud"
 LABEL "com.github.actions.color"="blue"
 
-# Copy entrypoint
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN npm install -g netlify-cli
 
-# Use shell entrypoint that preserves "$@"
-ENTRYPOINT ["sh", "-c", "/entrypoint.sh \"$@\""]
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,8 +1,5 @@
 FROM node:22-alpine
 
-# Add required tools: perl for stripping ANSI escape sequences
-RUN apk add --no-cache perl
-
 # Install Netlify CLI
 RUN npm install -g netlify-cli
 
@@ -16,5 +13,9 @@ LABEL "com.github.actions.description"="Wraps the Netlify CLI to enable common N
 LABEL "com.github.actions.icon"="cloud"
 LABEL "com.github.actions.color"="blue"
 
+# Copy entrypoint
 COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+RUN chmod +x /entrypoint.sh
+
+# Use shell entrypoint that preserves "$@"
+ENTRYPOINT ["sh", "-c", "/entrypoint.sh \"$@\""]

--- a/cli/README.md
+++ b/cli/README.md
@@ -11,10 +11,12 @@ This Action enables arbitrary actions with the [Netlify CLI](https://github.com/
 ## Outputs
 
 The following outputs will be available from a step that uses this action:
-- `NETLIFY_OUTPUT`, the full stdout from the run of the `netlify` command
 - `NETLIFY_URL`, the URL of the draft site that Netlify provides
 - `NETLIFY_LOGS_URL`, the URL where the logs from the deploy can be found
 - `NETLIFY_LIVE_URL`, the URL of the "real" site, set only if `--prod` was passed
+
+> The full stdout from the run of the `netlify` command is printed in the GitHub Actions workflow logs.
+
 
 See [the documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions) for info and examples of how to use outputs in later steps and jobs.
 
@@ -33,7 +35,7 @@ jobs:
     - name: Publish
       uses: netlify/actions/cli@master
       with:
-        args: deploy --dir=site --functions=functions
+        args: deploy --prod --dir=./build --message="Deploy from Github Action"
       env:
         NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -12,9 +12,9 @@ echo "running ${COMMAND}"
 OUTPUT=$(sh -c "$COMMAND")
 echo "$OUTPUT"
 
-NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(https?://[^ ]*--[^ ]*\.netlify\.app)')
-NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo 'https://app\.netlify\.com/[^ ]*')
-NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo 'https://[^ ]*\.stackql\.io')
+NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*') #Unique key: --
+NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*') #Unique key: app.netlify.com
+NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com") #Unique key: don't containr -- and app.netlify.com
 
 {
   echo "NETLIFY_URL=$NETLIFY_URL"

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -15,9 +15,16 @@ NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a
 NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*') #Unique key: app.netlify.com
 NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com") #Unique key: don't containr -- and app.netlify.com
 
-[ -n "$NETLIFY_OUTPUT" ] && echo "NETLIFY_OUTPUT=$NETLIFY_OUTPUT" >> "$GITHUB_OUTPUT"
-[ -n "$NETLIFY_URL" ] && echo "NETLIFY_URL=$NETLIFY_URL" >> "$GITHUB_OUTPUT"
-[ -n "$NETLIFY_LOGS_URL" ] && echo "NETLIFY_LOGS_URL=$NETLIFY_LOGS_URL" >> "$GITHUB_OUTPUT"
-[ -n "$NETLIFY_LIVE_URL" ] && echo "NETLIFY_LIVE_URL=$NETLIFY_LIVE_URL" >> "$GITHUB_OUTPUT"
+# Function to safely write outputs
+safe_output() {
+  local name="$1"
+  local value="$2"
+  if [ -n "$value" ]; then
+    echo "${name}=${value}" >> "$GITHUB_OUTPUT"
+  fi
+}
 
-
+safe_output "NETLIFY_OUTPUT" "$NETLIFY_OUTPUT"
+safe_output "NETLIFY_URL" "$NETLIFY_URL"
+safe_output "NETLIFY_LOGS_URL" "$NETLIFY_LOGS_URL"
+safe_output "NETLIFY_LIVE_URL" "$NETLIFY_LIVE_URL"

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -4,7 +4,7 @@ read -d '' COMMAND <<- EOF
   if [ -f "$HOME/ignore" ] && grep "^ignore:$BUILD_DIR" "$HOME/ignore"; then
     echo "$BUILD_DIR didn't change"
   else
-    ${BUILD_COMMAND:-echo} && netlify "$@"
+    ${BUILD_COMMAND:-echo} && netlify $@
   fi
 EOF
 

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -12,9 +12,9 @@ echo "running ${COMMAND}"
 OUTPUT=$(sh -c "$COMMAND")
 echo "$OUTPUT"
 
-NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*') #Unique key: --
-NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*') #Unique key: app.netlify.com
-NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com") #Unique key: don't containr -- and app.netlify.com
+NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*' | head -n 1)
+NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep "Build logs:" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*' | head -n 1)
+NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -i "production URL:" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | head -n 1)
 
 {
   echo "NETLIFY_URL=$NETLIFY_URL"

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -1,46 +1,30 @@
 #!/bin/sh -l
 
-# Build the command
 read -d '' COMMAND <<- EOF
-  if [ -f "$HOME/ignore" ] && grep "^ignore:$BUILD_DIR" "$HOME/ignore"; then
-    echo "$BUILD_DIR didn't change"
+  if [ -f "\$HOME/ignore" ] && grep "^ignore:\$BUILD_DIR" "\$HOME/ignore"; then
+    echo "\$BUILD_DIR didn't change"
   else
-    ${BUILD_COMMAND:-echo} && netlify "$@"
+    ${BUILD_COMMAND:-echo} && netlify $*
   fi
 EOF
 
-# Execute the command and capture output
 OUTPUT=$(sh -c "$COMMAND")
 
-# Extract values using grep patterns
 NETLIFY_OUTPUT=$(echo "$OUTPUT")
 NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*')
 NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*')
 NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com")
 
-# Function to safely write outputs
+# Safe writer to avoid invalid output errors
 safe_output() {
   local name="$1"
   local value="$2"
-
-  # Strip control characters (e.g., zero-width space)
   value=$(echo "$value" | tr -cd '[:print:]\n\r')
-
   if [ -n "$value" ]; then
     echo "${name}=${value}" >> "$GITHUB_OUTPUT"
   fi
 }
 
-# Optional debugging (uncomment to inspect)
-# echo "==== RAW OUTPUT ===="
-# echo "$OUTPUT"
-# echo "==== DEBUG OUTPUTS ===="
-# echo "NETLIFY_OUTPUT: $(echo "$NETLIFY_OUTPUT" | od -c)"
-# echo "NETLIFY_URL: $(echo "$NETLIFY_URL" | od -c)"
-# echo "NETLIFY_LOGS_URL: $(echo "$NETLIFY_LOGS_URL" | od -c)"
-# echo "NETLIFY_LIVE_URL: $(echo "$NETLIFY_LIVE_URL" | od -c)"
-
-# Write outputs
 safe_output "NETLIFY_OUTPUT" "$NETLIFY_OUTPUT"
 safe_output "NETLIFY_URL" "$NETLIFY_URL"
 safe_output "NETLIFY_LOGS_URL" "$NETLIFY_LOGS_URL"

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -4,7 +4,7 @@ read -d '' COMMAND <<- EOF
   if [ -f "$HOME/ignore" ] && grep "^ignore:$BUILD_DIR" "$HOME/ignore"; then
     echo "$BUILD_DIR didn't change"
   else
-    ${BUILD_COMMAND:-echo} && netlify $*
+    ${BUILD_COMMAND:-echo} && netlify "$@"
   fi
 EOF
 
@@ -12,13 +12,11 @@ echo "running ${COMMAND}"
 OUTPUT=$(sh -c "$COMMAND")
 echo "$OUTPUT"
 
-NETLIFY_OUTPUT=$(echo "$OUTPUT")
-NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*') #Unique key: --
-NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*') #Unique key: app.netlify.com
-NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com") #Unique key: don't containr -- and app.netlify.com
+NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(https?://[^ ]*--[^ ]*\.netlify\.app)')
+NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo 'https://app\.netlify\.com/[^ ]*')
+NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo 'https://[^ ]*\.stackql\.io')
 
 {
-  echo "NETLIFY_OUTPUT=$NETLIFY_OUTPUT"
   echo "NETLIFY_URL=$NETLIFY_URL"
   echo "NETLIFY_LOGS_URL=$NETLIFY_LOGS_URL"
   echo "NETLIFY_LIVE_URL=$NETLIFY_LIVE_URL"

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -15,7 +15,10 @@ NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a
 NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*') #Unique key: app.netlify.com
 NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com") #Unique key: don't containr -- and app.netlify.com
 
-echo "::set-output name=NETLIFY_OUTPUT::$NETLIFY_OUTPUT"
-echo "::set-output name=NETLIFY_URL::$NETLIFY_URL"
-echo "::set-output name=NETLIFY_LOGS_URL::$NETLIFY_LOGS_URL"
-echo "::set-output name=NETLIFY_LIVE_URL::$NETLIFY_LIVE_URL"
+{
+  echo "NETLIFY_OUTPUT=$NETLIFY_OUTPUT"
+  echo "NETLIFY_URL=$NETLIFY_URL"
+  echo "NETLIFY_LOGS_URL=$NETLIFY_LOGS_URL"
+  echo "NETLIFY_LIVE_URL=$NETLIFY_LIVE_URL"
+} >> "$GITHUB_OUTPUT"
+

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -1,100 +1,23 @@
 #!/bin/sh -l
 
-export TERM=dumb
-
-# Skip if this build dir is ignored
-if [ -f "$HOME/ignore" ] && grep "^ignore:$BUILD_DIR" "$HOME/ignore"; then
-  echo "$BUILD_DIR didn't change"
-  exit 0
-fi
-
-# Run the Netlify CLI with passed args and capture output
-RAW_OUTPUT=$(netlify "$@" 2>&1)
-EXIT_CODE=$?
-
-# Debug: show raw output
-echo "🪵 RAW OUTPUT:"
-echo "$RAW_OUTPUT" | od -c | head -40
-
-# Fail early if the command errored
-if [ $EXIT_CODE -ne 0 ]; then
-  echo "❌ Netlify CLI command failed (exit code $EXIT_CODE)"
-  echo "$RAW_OUTPUT"
-  exit $EXIT_CODE
-fi
-
-# Sanitize output
-SANITIZED_OUTPUT=$(echo "$RAW_OUTPUT" | perl -pe 's/\e\[?.*?[\@-~]//g' | tr -cd '[:print:]\n\r')
-
-echo "🪵 CLEAN OUTPUT:"
-echo "$SANITIZED_OUTPUT"
-
-# Parse output
-NETLIFY_OUTPUT="$SANITIZED_OUTPUT"
-NETLIFY_URL=$(echo "$SANITIZED_OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*')
-NETLIFY_LOGS_URL=$(echo "$SANITIZED_OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*')
-NETLIFY_LIVE_URL=$(echo "$SANITIZED_OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com")
-
-# Output to GitHub environment
-safe_output() {
-  local name="$1"
-  local value="$2"
-  if [ -n "$value" ]; then
-    echo "${name}=${value}" >> "$GITHUB_OUTPUT"
+read -d '' COMMAND <<- EOF
+  if [ -f "$HOME/ignore" ] && grep "^ignore:$BUILD_DIR" "$HOME/ignore"; then
+    echo "$BUILD_DIR didn't change"
+  else
+    ${BUILD_COMMAND:-echo} && netlify $*
   fi
-}
+EOF
 
-safe_output "NETLIFY_OUTPUT" "$NETLIFY_OUTPUT"
-safe_output "NETLIFY_URL" "$NETLIFY_URL"
-safe_output "NETLIFY_LOGS_URL" "$NETLIFY_LOGS_URL"
-safe_output "NETLIFY_LIVE_URL" "$NETLIFY_LIVE_URL"
-#!/bin/sh -l
+OUTPUT=$(sh -c "$COMMAND")
 
-export TERM=dumb
+NETLIFY_OUTPUT=$(echo "$OUTPUT")
+NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*')
+NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*')
+NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com")
 
-# Skip if this build dir is ignored
-if [ -f "$HOME/ignore" ] && grep "^ignore:$BUILD_DIR" "$HOME/ignore"; then
-  echo "$BUILD_DIR didn't change"
-  exit 0
-fi
-
-# Run the Netlify CLI with passed args and capture output
-RAW_OUTPUT=$(netlify "$@" 2>&1)
-EXIT_CODE=$?
-
-# Debug: show raw output
-echo "🪵 RAW OUTPUT:"
-echo "$RAW_OUTPUT" | od -c | head -40
-
-# Fail early if the command errored
-if [ $EXIT_CODE -ne 0 ]; then
-  echo "❌ Netlify CLI command failed (exit code $EXIT_CODE)"
-  echo "$RAW_OUTPUT"
-  exit $EXIT_CODE
-fi
-
-# Sanitize output
-SANITIZED_OUTPUT=$(echo "$RAW_OUTPUT" | perl -pe 's/\e\[?.*?[\@-~]//g' | tr -cd '[:print:]\n\r')
-
-echo "🪵 CLEAN OUTPUT:"
-echo "$SANITIZED_OUTPUT"
-
-# Parse output
-NETLIFY_OUTPUT="$SANITIZED_OUTPUT"
-NETLIFY_URL=$(echo "$SANITIZED_OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*')
-NETLIFY_LOGS_URL=$(echo "$SANITIZED_OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*')
-NETLIFY_LIVE_URL=$(echo "$SANITIZED_OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com")
-
-# Output to GitHub environment
-safe_output() {
-  local name="$1"
-  local value="$2"
-  if [ -n "$value" ]; then
-    echo "${name}=${value}" >> "$GITHUB_OUTPUT"
-  fi
-}
-
-safe_output "NETLIFY_OUTPUT" "$NETLIFY_OUTPUT"
-safe_output "NETLIFY_URL" "$NETLIFY_URL"
-safe_output "NETLIFY_LOGS_URL" "$NETLIFY_LOGS_URL"
-safe_output "NETLIFY_LIVE_URL" "$NETLIFY_LIVE_URL"
+{
+  echo "NETLIFY_OUTPUT=$NETLIFY_OUTPUT"
+  echo "NETLIFY_URL=$NETLIFY_URL"
+  echo "NETLIFY_LOGS_URL=$NETLIFY_LOGS_URL"
+  echo "NETLIFY_LIVE_URL=$NETLIFY_LIVE_URL"
+} >> "$GITHUB_OUTPUT"

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -15,10 +15,9 @@ NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a
 NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*') #Unique key: app.netlify.com
 NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com") #Unique key: don't containr -- and app.netlify.com
 
-{
-  echo "NETLIFY_OUTPUT=$NETLIFY_OUTPUT"
-  echo "NETLIFY_URL=$NETLIFY_URL"
-  echo "NETLIFY_LOGS_URL=$NETLIFY_LOGS_URL"
-  echo "NETLIFY_LIVE_URL=$NETLIFY_LIVE_URL"
-} >> "$GITHUB_OUTPUT"
+[ -n "$NETLIFY_OUTPUT" ] && echo "NETLIFY_OUTPUT=$NETLIFY_OUTPUT" >> "$GITHUB_OUTPUT"
+[ -n "$NETLIFY_URL" ] && echo "NETLIFY_URL=$NETLIFY_URL" >> "$GITHUB_OUTPUT"
+[ -n "$NETLIFY_LOGS_URL" ] && echo "NETLIFY_LOGS_URL=$NETLIFY_LOGS_URL" >> "$GITHUB_OUTPUT"
+[ -n "$NETLIFY_LIVE_URL" ] && echo "NETLIFY_LIVE_URL=$NETLIFY_LIVE_URL" >> "$GITHUB_OUTPUT"
+
 

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -10,6 +10,9 @@ EOF
 
 OUTPUT=$(sh -c "$COMMAND")
 
+echo "🪵 RAW CLI OUTPUT:"
+echo "$OUTPUT" | od -c  # This shows non-printable chars as octal escapes
+
 NETLIFY_OUTPUT=$(echo "$OUTPUT")
 NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*')
 NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*')

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -1,29 +1,46 @@
 #!/bin/sh -l
 
+# Build the command
 read -d '' COMMAND <<- EOF
   if [ -f "$HOME/ignore" ] && grep "^ignore:$BUILD_DIR" "$HOME/ignore"; then
     echo "$BUILD_DIR didn't change"
   else
-    ${BUILD_COMMAND:-echo} && netlify $*
+    ${BUILD_COMMAND:-echo} && netlify "$@"
   fi
 EOF
 
+# Execute the command and capture output
 OUTPUT=$(sh -c "$COMMAND")
 
+# Extract values using grep patterns
 NETLIFY_OUTPUT=$(echo "$OUTPUT")
-NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*') #Unique key: --
-NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*') #Unique key: app.netlify.com
-NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com") #Unique key: don't containr -- and app.netlify.com
+NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*')
+NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*')
+NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com")
 
 # Function to safely write outputs
 safe_output() {
   local name="$1"
   local value="$2"
+
+  # Strip control characters (e.g., zero-width space)
+  value=$(echo "$value" | tr -cd '[:print:]\n\r')
+
   if [ -n "$value" ]; then
     echo "${name}=${value}" >> "$GITHUB_OUTPUT"
   fi
 }
 
+# Optional debugging (uncomment to inspect)
+# echo "==== RAW OUTPUT ===="
+# echo "$OUTPUT"
+# echo "==== DEBUG OUTPUTS ===="
+# echo "NETLIFY_OUTPUT: $(echo "$NETLIFY_OUTPUT" | od -c)"
+# echo "NETLIFY_URL: $(echo "$NETLIFY_URL" | od -c)"
+# echo "NETLIFY_LOGS_URL: $(echo "$NETLIFY_LOGS_URL" | od -c)"
+# echo "NETLIFY_LIVE_URL: $(echo "$NETLIFY_LIVE_URL" | od -c)"
+
+# Write outputs
 safe_output "NETLIFY_OUTPUT" "$NETLIFY_OUTPUT"
 safe_output "NETLIFY_URL" "$NETLIFY_URL"
 safe_output "NETLIFY_LOGS_URL" "$NETLIFY_LOGS_URL"

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -2,44 +2,90 @@
 
 export TERM=dumb
 
-# Build command to run netlify
-read -d '' COMMAND <<- EOF
-  if [ -f "\$HOME/ignore" ] && grep "^ignore:\$BUILD_DIR" "\$HOME/ignore"; then
-    echo "\$BUILD_DIR didn't change"
-  else
-    ${BUILD_COMMAND:-echo} && netlify "$@"
-  fi
-EOF
+# Skip if this build dir is ignored
+if [ -f "$HOME/ignore" ] && grep "^ignore:$BUILD_DIR" "$HOME/ignore"; then
+  echo "$BUILD_DIR didn't change"
+  exit 0
+fi
 
-# Run command and capture status
-RAW_OUTPUT=$(sh -c "$COMMAND" 2>&1)
+# Run the Netlify CLI with passed args and capture output
+RAW_OUTPUT=$(netlify "$@" 2>&1)
 EXIT_CODE=$?
 
-# Debug dump (optional)
+# Debug: show raw output
 echo "🪵 RAW OUTPUT:"
 echo "$RAW_OUTPUT" | od -c | head -40
 
-# Fail if command did not succeed
+# Fail early if the command errored
 if [ $EXIT_CODE -ne 0 ]; then
   echo "❌ Netlify CLI command failed (exit code $EXIT_CODE)"
   echo "$RAW_OUTPUT"
   exit $EXIT_CODE
 fi
 
-# Strip ANSI escape sequences and non-printables
+# Sanitize output
 SANITIZED_OUTPUT=$(echo "$RAW_OUTPUT" | perl -pe 's/\e\[?.*?[\@-~]//g' | tr -cd '[:print:]\n\r')
 
-# Debug sanitized output
 echo "🪵 CLEAN OUTPUT:"
 echo "$SANITIZED_OUTPUT"
 
-# Extract values
+# Parse output
 NETLIFY_OUTPUT="$SANITIZED_OUTPUT"
 NETLIFY_URL=$(echo "$SANITIZED_OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*')
 NETLIFY_LOGS_URL=$(echo "$SANITIZED_OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*')
 NETLIFY_LIVE_URL=$(echo "$SANITIZED_OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com")
 
-# Safely write outputs
+# Output to GitHub environment
+safe_output() {
+  local name="$1"
+  local value="$2"
+  if [ -n "$value" ]; then
+    echo "${name}=${value}" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+safe_output "NETLIFY_OUTPUT" "$NETLIFY_OUTPUT"
+safe_output "NETLIFY_URL" "$NETLIFY_URL"
+safe_output "NETLIFY_LOGS_URL" "$NETLIFY_LOGS_URL"
+safe_output "NETLIFY_LIVE_URL" "$NETLIFY_LIVE_URL"
+#!/bin/sh -l
+
+export TERM=dumb
+
+# Skip if this build dir is ignored
+if [ -f "$HOME/ignore" ] && grep "^ignore:$BUILD_DIR" "$HOME/ignore"; then
+  echo "$BUILD_DIR didn't change"
+  exit 0
+fi
+
+# Run the Netlify CLI with passed args and capture output
+RAW_OUTPUT=$(netlify "$@" 2>&1)
+EXIT_CODE=$?
+
+# Debug: show raw output
+echo "🪵 RAW OUTPUT:"
+echo "$RAW_OUTPUT" | od -c | head -40
+
+# Fail early if the command errored
+if [ $EXIT_CODE -ne 0 ]; then
+  echo "❌ Netlify CLI command failed (exit code $EXIT_CODE)"
+  echo "$RAW_OUTPUT"
+  exit $EXIT_CODE
+fi
+
+# Sanitize output
+SANITIZED_OUTPUT=$(echo "$RAW_OUTPUT" | perl -pe 's/\e\[?.*?[\@-~]//g' | tr -cd '[:print:]\n\r')
+
+echo "🪵 CLEAN OUTPUT:"
+echo "$SANITIZED_OUTPUT"
+
+# Parse output
+NETLIFY_OUTPUT="$SANITIZED_OUTPUT"
+NETLIFY_URL=$(echo "$SANITIZED_OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*')
+NETLIFY_LOGS_URL=$(echo "$SANITIZED_OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*')
+NETLIFY_LIVE_URL=$(echo "$SANITIZED_OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com")
+
+# Output to GitHub environment
 safe_output() {
   local name="$1"
   local value="$2"

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -8,12 +8,14 @@ read -d '' COMMAND <<- EOF
   fi
 EOF
 
+echo "running ${COMMAND}"
 OUTPUT=$(sh -c "$COMMAND")
+echo "$OUTPUT"
 
 NETLIFY_OUTPUT=$(echo "$OUTPUT")
-NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*')
-NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*')
-NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com")
+NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*') #Unique key: --
+NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*') #Unique key: app.netlify.com
+NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com") #Unique key: don't containr -- and app.netlify.com
 
 {
   echo "NETLIFY_OUTPUT=$NETLIFY_OUTPUT"

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -l
 
-# Disable terminal formatting from Netlify CLI
+# Disable formatting from Netlify CLI
 export TERM=dumb
 
 # Build the command block
@@ -12,25 +12,25 @@ read -d '' COMMAND <<- EOF
   fi
 EOF
 
-# Execute command and capture raw output
+# Execute command and capture raw output (stdout + stderr)
 RAW_OUTPUT=$(sh -c "$COMMAND" 2>&1)
 
-# Strip ANSI escape sequences and Unicode line art safely
-SANITIZED_OUTPUT=$(echo "$RAW_OUTPUT" | perl -pe 's/\e\[?.*?[\@-~]//g' | iconv -f utf-8 -t ascii//TRANSLIT)
+# Strip ANSI escape sequences (e.g. \033[31m) and remove non-printables
+SANITIZED_OUTPUT=$(echo "$RAW_OUTPUT" | perl -pe 's/\e\[?.*?[\@-~]//g' | tr -cd '[:print:]\n\r')
 
-# Optional: debug dump
+# Optional debug
 echo "🪵 RAW OUTPUT:"
 echo "$RAW_OUTPUT" | od -c | head -40
 echo "🪵 CLEAN OUTPUT:"
 echo "$SANITIZED_OUTPUT"
 
-# Parse values
+# Parse sanitized output for relevant Netlify URLs
 NETLIFY_OUTPUT="$SANITIZED_OUTPUT"
 NETLIFY_URL=$(echo "$SANITIZED_OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*')
 NETLIFY_LOGS_URL=$(echo "$SANITIZED_OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*')
 NETLIFY_LIVE_URL=$(echo "$SANITIZED_OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com")
 
-# Safe writer to GitHub output
+# Write sanitized values to GitHub output file
 safe_output() {
   local name="$1"
   local value="$2"


### PR DESCRIPTION
### Summary

Replaces the deprecated `::set-output` syntax in `entrypoint.sh` with the secure, modern `$GITHUB_OUTPUT` approach, in line with [GitHub's deprecation notice](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

### Why

- Removes warnings in GitHub Actions
- Future-proofs this action
- Avoids eventual breaking behavior when GitHub disables `set-output`

---

Tested in a fork and validated with a working GitHub workflow.
